### PR TITLE
support 3d model nft preview

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,52 +11,53 @@
 
     </queries>
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-   <application
+    <application
+        android:icon="@mipmap/ic_launcher"
         android:label="Easel"
-        android:icon="@mipmap/ic_launcher">
+        android:usesCleartextTraffic="true">
+        
         <activity
             android:name="tech.pylons.easel.MainActivity"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:exported="true"
+            android:hardwareAccelerated="true"
             android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
-            android:exported="true"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
-            android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <!-- Displays an Android View that continues showing the launch screen
                  Drawable until Flutter paints its first frame, then this splash
                  screen fades out. A splash screen is useful to avoid any visual
                  gap between the end of Android's launch screen and the painting of
                  Flutter's first frame. -->
             <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
+                android:name="io.flutter.embedding.android.SplashScreenDrawable"
+                android:resource="@drawable/launch_background" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
             <!-- Pylons Links -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Accepts URIs that begin with YOUR_SCHEME://YOUR_HOST -->
                 <data
-                    android:scheme="pylons"
-                    android:host="easel" />
+                    android:host="easel"
+                    android:scheme="pylons" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/models/nft_format.dart
+++ b/lib/models/nft_format.dart
@@ -13,5 +13,5 @@ class NftFormat {
         NftFormat(format: kVideoText, extensions: ['mp4', 'mov', 'm4v', 'avi']),
         NftFormat(format: k3dText, extensions: ['gltf', 'glb']),
         NftFormat(format: kAudioText, extensions: ['wav', 'aiff', 'alac', 'flac', 'mp3', 'aac', 'wma', 'ogg']),
-      ];
+  ];
 }

--- a/lib/screens/mint_screen.dart
+++ b/lib/screens/mint_screen.dart
@@ -1,4 +1,5 @@
 import 'package:easel_flutter/easel_provider.dart';
+import 'package:easel_flutter/screens/model_viewer_screen.dart';
 import 'package:easel_flutter/utils/constants.dart';
 import 'package:easel_flutter/utils/date_utils.dart';
 import 'package:easel_flutter/utils/easel_app_theme.dart';
@@ -37,6 +38,30 @@ class MintScreen extends StatelessWidget {
                   ],
                   if (provider.nftFormat.format == kVideoText) ...[
                     VideoWidget(file: provider.file!)
+                  ],
+                  if (provider.nftFormat.format == k3dText) ...[
+                    Center(
+                        child: TextButton(
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                      ModelViewerScreen(file: provider.file!)),
+                            );
+                          },
+                          child: Text(
+                            kPreview3dModelText,
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyText1!
+                                .copyWith(
+                                    fontSize: 16,
+                                    color: EaselAppTheme.kBlue,
+                                    fontWeight: FontWeight.w400),
+                          ),
+                        )),
                   ],
                   if (provider.nftFormat.format == kAudioText) ...[
                     AudioWidget(file: provider.file!)

--- a/lib/screens/model_viewer_screen.dart
+++ b/lib/screens/model_viewer_screen.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:model_viewer/model_viewer.dart';
+import 'package:path/path.dart';
+
+class ModelViewerScreen extends StatelessWidget {
+  final File file;
+
+  const ModelViewerScreen({Key? key, required this.file}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(basename(file.path))),
+      body: ModelViewer(
+        // src: 'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
+        src: 'file://${file.path}',
+        ar: true,
+        autoRotate: true,
+        cameraControls: true,
+      ),
+    );
+  }
+}

--- a/lib/screens/upload_screen.dart
+++ b/lib/screens/upload_screen.dart
@@ -55,7 +55,6 @@ class _UploadScreenState extends State<UploadScreen> {
                       widget.controller.nextPage(
                           duration: const Duration(milliseconds: 300),
                           curve: Curves.easeIn);
-
                     } else {
                       errorText.value = 'Pick a file';
                       showError.value = true;
@@ -111,7 +110,13 @@ class _UploadWidgetState extends State<_UploadWidget> {
             child: GestureDetector(
               onTap: () async {
                 final result = await FileUtils.pickFile(provider.nftFormat);
-                widget.onFilePicked(result);
+                if (result == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                    content: Text("Unsupported format."),
+                  ));
+                } else {
+                  widget.onFilePicked(result);
+                }
               },
               child: Image.asset(kFileIcon),
             ),

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -48,6 +48,7 @@ const kDurationText = "Duration";
 const kDateText = "Date";
 const kRoyaltyText = "Royalty";
 const kPreviewNFTText = "Preview NFT";
+const kPreview3dModelText = "Click here to preview\nyour selected 3D Model";
 const kMintMoreText = "Mint More";
 const kGoToWalletText = "Go to Wallet";
 const kChooseNFTFormatText = "Choose your NFT format";

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -13,18 +13,28 @@ class FileUtils {
   ///
   /// or null if aborted
   static Future<PlatformFile?> pickFile(NftFormat format) async {
-    FileType _type = FileType.any;
-    if (format.format == kImageText) {
-      _type = FileType.image;
-    } else if (format.format == kVideoText) {
-      _type = FileType.video;
-    } else if (format.format == kAudioText) {
-      _type = FileType.audio;
+    FileType _type;
+    switch (format.format) {
+      case kImageText:
+        _type = FileType.image;
+        break;
+      case kVideoText:
+        _type = FileType.video;
+        break;
+      case kAudioText:
+        _type = FileType.audio;
+        break;
+      default:
+        _type = FileType.any;
+        break;
     }
+
     FilePickerResult? result = await FilePicker.platform.pickFiles(type: _type);
-    if (result != null) {
+
+    if (result != null && format.extensions.contains(result.files.single.extension)) {
       return result.files.single;
     }
+
     return null;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
 
 # file_picker plugin is used so we can pick single/multiple files with extension filtering support.
 #  with this plugin, we can filter the file extension(not just images) we want users to pick.
-  file_picker: ^4.2.2
+  file_picker: ^4.5.0
 
   path: ^1.8.0
 
@@ -69,6 +69,7 @@ dependencies:
   video_player: ^2.2.18
   just_audio: ^0.9.19
   audio_video_progress_bar: ^0.10.0
+  model_viewer: ^0.8.1
 
 # used for bitmap manipulation, needed for svg to png conversion
 #  bitmap: ^0.1.2


### PR DESCRIPTION
- Added the 3d model nft preview (using `model_viewer` package for now)
- Customized file picker filtering as the `FileType.custom` filter doesn't work for all file extensions

Note:
`model_viewer` doesn't opt in to null safety so the project will only run with an additional arg. (--no-sound-null-safety)